### PR TITLE
Add associate_public_ip_address option

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,8 @@ resource "aws_instance" "ssh_bastion" {
 
   vpc_security_group_ids = [aws_security_group.ssh_bastion.id]
 
+  associate_public_ip_address = var.associate_public_ip_address
+
   # Install unattended-upgrade package to automatically install security updates
   user_data = <<-EOF
               #!/bin/bash

--- a/variables.tf
+++ b/variables.tf
@@ -37,3 +37,9 @@ variable "instance_type" {
   description = "Instance type"
   default     = "t2.micro"
 }
+
+variable "associate_public_ip_address" {
+  type        = bool
+  description = "Associate a public IP address with the instance"
+  default     = true
+}


### PR DESCRIPTION
Adding `associate_public_ip_address` option as if the subnet does not have it enabled by default, the instance will be created without a public IP.